### PR TITLE
Comando PERFIL & modificação para build:start

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "node dist/index.js",
     "build": "npm run build:clean && npm run build:compile",
     "build:start": "npm run build && npm run start",
+    "build:start:nodb": "npm run build ; npm run start",
     "build:clean": "rimraf dist/",
     "build:compile": "tsc",
     "watch": "tsx --watch ./src/"

--- a/src/commands/Information/perfil.ts
+++ b/src/commands/Information/perfil.ts
@@ -26,7 +26,7 @@ export default class InfoCommand {
     ): Promise<void> {
 	if (!member) member = await interaction.guild?.members.fetch(interaction?.user.id);
 	if (member instanceof GuildMember)
-	    interaction.reply(`### Informações de ${member.user.username}\n\`ID\`: ${member?.id}\n\n\`Entrou em\`:\n${member?.joinedAt?.toLocaleDateString("pt-br")}\n\`Criou em\`:\n${member?.user.createdAt.toLocaleDateString("pt-br")}`);
+	    interaction.reply(`### Informações de ${member.user.username}\n\`ID\`: ${member?.id}\n\n\`Entrou em\`:\n${member?.joinedAt?.toLocaleDateString("pt-br")}\n\`Criou em\`:\n${member?.user.createdAt.toLocaleDateString("pt-br")}\n`);
 	    
 	
     }

--- a/src/commands/Information/perfil.ts
+++ b/src/commands/Information/perfil.ts
@@ -1,0 +1,33 @@
+import { Discord, Slash, SlashOption } from "discordx";
+import { Category } from "@discordx/utilities";
+import {
+    APIInteractionGuildMember,
+    ApplicationCommandOptionType,
+    CommandInteraction,
+    GuildMember,
+} from "discord.js";
+
+@Discord()
+@Category("Information")
+export default class InfoCommand {
+    @Slash({
+        name: "perfil",
+        description: "exibir informações de um usuário",
+    })
+    async information(
+        @SlashOption({
+            name: "member",
+            description: "alvo para ver o comando",
+            required: false,
+            type: ApplicationCommandOptionType.Mentionable,
+        })
+        member: GuildMember | APIInteractionGuildMember | undefined,
+        interaction: CommandInteraction,
+    ): Promise<void> {
+	if (!member) member = await interaction.guild?.members.fetch(interaction?.user.id);
+	if (member instanceof GuildMember)
+	    interaction.reply(`### Informações de ${member.user.username}\n\`ID\`: ${member?.id}\n\n\`Entrou em\`:\n${member?.joinedAt?.toLocaleDateString("pt-br")}\n\`Criou em\`:\n${member?.user.createdAt.toLocaleDateString("pt-br")}`);
+	    
+	
+    }
+}


### PR DESCRIPTION
1. criei uma base inicial para o comando. Vou melhorar amanhã;
2. foi feito uma modificação para o uso sem database do bot. Eu ainda não instalei as coisas, então estou sem como rodar usando o operador `&&` e criei um extra `build:start:nodb` para rodar com `;`.